### PR TITLE
Custom first last name validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.0.0 

--- a/lib/ama_validators.rb
+++ b/lib/ama_validators.rb
@@ -8,5 +8,6 @@ module AmaValidators
   require 'ama_validators/membership_number_format_validator'
   require 'ama_validators/phone_number_format_validator'
   require 'ama_validators/province_validator'
+  require 'ama_validators/name_format_validator'
 
 end

--- a/lib/ama_validators/name_format_validator.rb
+++ b/lib/ama_validators/name_format_validator.rb
@@ -1,0 +1,7 @@
+class NameFormatValidator < ActiveModel::EachValidator
+  def validate_each(object, attribute, value)
+    unless value =~ /\A[a-zA-Z]+\z/
+      object.errors[attribute] << (options[:message] || "We're sorry your name cannot contain any special characters")
+    end
+  end
+end

--- a/lib/ama_validators/name_format_validator.rb
+++ b/lib/ama_validators/name_format_validator.rb
@@ -1,6 +1,6 @@
 class NameFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
-    unless value =~ /\A[a-zA-ZÀàÂâÄäÈèÉéÊêËëÎîÏïÔôŒœÙùÛûÜüŸÿÇç,.'-]+\z/
+    unless value =~ /\A[\sa-zA-ZÀàÂâÄäÈèÉéÊêËëÎîÏïÔôŒœÙùÛûÜüŸÿÇç,.'-]+\z/
       object.errors[attribute] << (options[:message] || "We're sorry your name cannot contain any special characters")
     end
   end

--- a/lib/ama_validators/name_format_validator.rb
+++ b/lib/ama_validators/name_format_validator.rb
@@ -1,6 +1,6 @@
 class NameFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
-    unless value =~ /\A[a-zA-Z]+\z/
+    unless value =~ /\A[a-zA-Z,.'-]+\z/
       object.errors[attribute] << (options[:message] || "We're sorry your name cannot contain any special characters")
     end
   end

--- a/lib/ama_validators/name_format_validator.rb
+++ b/lib/ama_validators/name_format_validator.rb
@@ -1,6 +1,6 @@
 class NameFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
-    unless value =~ /\A[a-zA-Z,.'-]+\z/
+    unless value =~ /\A[a-zA-ZÀàÂâÄäÈèÉéÊêËëÎîÏïÔôŒœÙùÛûÜüŸÿÇç,.'-]+\z/
       object.errors[attribute] << (options[:message] || "We're sorry your name cannot contain any special characters")
     end
   end

--- a/lib/ama_validators/version.rb
+++ b/lib/ama_validators/version.rb
@@ -1,3 +1,3 @@
 module AmaValidators
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/spec/name_format_validator_spec.rb
+++ b/spec/name_format_validator_spec.rb
@@ -1,0 +1,51 @@
+require 'factories/profiles.rb'
+
+describe NameFormatValidator do
+
+  let(:subject) { NameFormatValidator }
+  let (:object) { Profile.new }
+
+  invalid_names = %w[A%^dam G∫ Ra©©øøl œ∑´®††a †††¬∆µ ©ƒ∂ßåΩ ≈ç√∫µ@]
+  valid_names = %w[George Jerry Elaine Kramer Jean-François Noël étè]
+
+  context 'Wrong name format' do
+    context 'No message is sent on the options' do
+      it 'it returns error message expecified on the validator' do
+        n  = subject.new( { attributes: :first_name } )
+        invalid_names.each do |invalid_name|
+          expect(n.validate_each(object, :first_name, invalid_name)).to include("We're sorry your name cannot contain any special characters")
+        end
+      end
+    end
+
+    context 'Message is sent on the options' do
+      it 'it returns error message expecified on the options' do
+        n  = subject.new( { message: 'Test error message', attributes: :first_name } )
+        invalid_names.each do |invalid_name|
+          expect(n.validate_each(object, :first_name, invalid_name)).to include('Test error message')
+        end
+      end
+    end
+  end
+
+  context 'Correct name format' do
+
+    context 'No message is sent on the options' do
+      it 'it does not return error message' do
+        n  = subject.new( { attributes: :first_name } )
+        valid_names.each do |valid_name|
+          expect(n.validate_each(object, :first_name, valid_name)).to equal(nil)
+        end
+      end
+    end
+
+    context 'Message is sent on the options' do
+      it 'it does not return error message' do
+        n  = subject.new( { message: 'Test error message', attributes: :first_name } )
+        valid_names.each do |valid_name|
+          expect(n.validate_each(object, :first_name, valid_name)).to equal(nil)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some of our vendors do not support certain types of characters, such as the company that prints the membership cards. This addition is to ensure that people do not add special characters in their name such as ß∂ƒ©˙∆˚¬ˆ¨¥†®´®ƒ©∫˜.

* Also had to bump the version of ruby since it was having issues with most of the special characters causing travis to break.

https://ama-digital.myjetbrains.com/youtrack/issue/MEMBR-1113

TODO: Will need spaces in names as well as dashes
WIP: Still looking for a full list of acceptable or unacceptable characters