### PR TITLE
Added brackets around | (or) options

### DIFF
--- a/lib/ama_validators/postal_code_format_validator.rb
+++ b/lib/ama_validators/postal_code_format_validator.rb
@@ -1,6 +1,6 @@
 class PostalCodeFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
-    unless value =~ /\A(\d{5}((-|\s)\d{4})?)|([txTX]\d[abceghjklmnprstvwxyzABCEGHJKLMNPRSTVWXYZ])\ {0,1}(\d[abceghjklmnprstvwxyzABCEGHJKLMNPRSTVWXYZ]\d)\z/
+    unless value =~ /\A(\d{5}((-|\s)\d{4})?|[txTX]\d[abceghjklmnprstvwxyzABCEGHJKLMNPRSTVWXYZ]\s{0,1}\d[abceghjklmnprstvwxyzABCEGHJKLMNPRSTVWXYZ]\d)\z/
       object.errors[attribute] << (options[:message] || "enter a valid AB or NT postal code (e.g. T4C 1A5)")
     end
   end

--- a/lib/ama_validators/version.rb
+++ b/lib/ama_validators/version.rb
@@ -1,3 +1,3 @@
 module AmaValidators
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/spec/postal_code_format_validator_spec.rb
+++ b/spec/postal_code_format_validator_spec.rb
@@ -7,8 +7,8 @@ describe PostalCodeFormatValidator do
   let( :attribute ) { :postal_code }
   let (:object) { Profile.new }
 
-  invalid_postal_codes = %w[2w2e3e b4hk6j t556v7 x2ceee t3x6sv T5j5M/]
-  valid_postal_codes = %w[T5w4g5 T5W4G5 X4H3J9 t6J4M5 x3B5X8]
+  invalid_postal_codes = %w[2w2e3e b4hk6j t556v7 x2ceee t3x6sv T5j5M/ 123456]
+  valid_postal_codes = %w[T5w4g5 T5W4G5 X4H3J9 t6J4M5 x3B5X8 12345 12345-6789]
 
   context 'Wrong postal code format' do
 


### PR DESCRIPTION
- Or condition was not correctly applied without surrounding brackets ex: (a|b), allowing 123456 through
- Removed unnecessary brackets
- Added valid/invalid test cases