### PR TITLE
165702-Update Gem for Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-sudo: false
-rvm:
-  - 2.3.1

--- a/ama_validators.gemspec
+++ b/ama_validators.gemspec
@@ -6,8 +6,8 @@ require 'ama_validators/version'
 Gem::Specification.new do |spec|
   spec.name          = "ama_validators"
   spec.version       = AmaValidators::VERSION
-  spec.authors       = ["Michael van den Beuken", "Ruben Estevez", "Jordan Babe", "Mathieu Gilbert", "Ryan Jones", "Darko Dosenovic"]
-  spec.email         = ["michael.beuken@gmail.com", "ruben.a.estevez@gmail.com", "jorbabe@gmail.com", "mathieu.gilbert@ama.ab.ca", "ryan.michael.jones@gmail.com", "darko.dosenovic@ama.ab.ca"]
+  spec.authors       = ["Michael van den Beuken", "Ruben Estevez", "Jordan Babe", "Mathieu Gilbert", "Ryan Jones", "Darko Dosenovic", "Zoie Carnegie"]
+  spec.email         = ["michael.beuken@gmail.com", "ruben.a.estevez@gmail.com", "jorbabe@gmail.com", "mathieu.gilbert@ama.ab.ca", "ryan.michael.jones@gmail.com", "darko.dosenovic@ama.ab.ca", "zoie.carnegie@gmail.com"]
   spec.description   = "Compile the following validators: - Credit card - Email - Membership number - Phone number - Postal code"
   spec.summary       = "This gem will compile the following validators - Credit card - Email - Membership number - Phone number - Postal code. With this gem there is no need for the validators classes."
   spec.homepage      = "https://github.com/amaabca/ama_validators"
@@ -18,12 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-instafail"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "coveralls"
-  spec.add_dependency "rails", ">= 3.0.0"
-
+  spec.add_development_dependency "simplecov", ">= 0.22.0"
+  spec.add_development_dependency "pry"
+  spec.add_dependency "rails", ">= 6.1.0"
 end

--- a/lib/ama_validators.rb
+++ b/lib/ama_validators.rb
@@ -1,7 +1,6 @@
 require "ama_validators/version"
 
 module AmaValidators
-
   require 'ama_validators/postal_code_format_validator'
   require 'ama_validators/email_format_validator'
   require 'ama_validators/credit_card_format_validator'
@@ -10,5 +9,4 @@ module AmaValidators
   require 'ama_validators/province_validator'
   require 'ama_validators/name_format_validator'
   require 'ama_validators/alphanumeric_name_format_validator'
-
 end

--- a/lib/ama_validators/alphanumeric_name_format_validator.rb
+++ b/lib/ama_validators/alphanumeric_name_format_validator.rb
@@ -1,7 +1,7 @@
 class AlphanumericNameFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     unless value =~ /\A[\s\da-zA-ZÀàÂâÄäÈèÉéÊêËëÎîÏïÔôŒœÙùÛûÜüŸÿÇç,.'\-\)\(]+\z/
-      object.errors[attribute] << (options[:message] || "We're sorry your name cannot contain any special characters")
+      object.errors.add(attribute, options[:message] || "We're sorry your name cannot contain any special characters")
     end
   end
 end

--- a/lib/ama_validators/credit_card_format_validator.rb
+++ b/lib/ama_validators/credit_card_format_validator.rb
@@ -1,7 +1,7 @@
 class CreditCardFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     unless value =~ /((4\d{3})|(5[1-5]\d{2})|(6011)|(34\d{1})|(37\d{1}))-?\d{4}-?\d{4}-?\d{4}|3[4,7][\d\s-]{15}/
-      object.errors[attribute] << (options[:message] || "enter a valid credit card number (Visa or Mastercard)")
+      object.errors.add(attribute, options[:message] || "enter a valid credit card number (Visa or Mastercard)")
     end
   end
 end

--- a/lib/ama_validators/email_format_validator.rb
+++ b/lib/ama_validators/email_format_validator.rb
@@ -1,7 +1,7 @@
 class EmailFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     unless value =~ /\A[^`@\s]+@([^@`\s\.]+\.)+[^`@\s\.]+\z/
-      object.errors[attribute] << (options[:message] || "enter a valid email address (e.g. name@example.com)")
+      object.errors.add(attribute, options[:message] || "enter a valid email address (e.g. name@example.com)")
     end
   end
 end

--- a/lib/ama_validators/membership_number_format_validator.rb
+++ b/lib/ama_validators/membership_number_format_validator.rb
@@ -1,7 +1,7 @@
 class MembershipNumberFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     unless value =~ /\A(620272)(\d){10}\z/
-      object.errors[attribute] << (options[:message] || "must be a valid 16-digit membership number")
+      object.errors.add(attribute, options[:message] || "must be a valid 16-digit membership number")
     end
   end
 end

--- a/lib/ama_validators/name_format_validator.rb
+++ b/lib/ama_validators/name_format_validator.rb
@@ -1,7 +1,7 @@
 class NameFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     unless value =~ /\A[\sa-zA-ZÀàÂâÄäÈèÉéÊêËëÎîÏïÔôŒœÙùÛûÜüŸÿÇç,.'\-\)\(]+\z/
-      object.errors[attribute] << (options[:message] || "We're sorry your name cannot contain any special characters")
+      object.errors.add(attribute, options[:message] || "We're sorry your name cannot contain any special characters")
     end
   end
 end

--- a/lib/ama_validators/phone_number_format_validator.rb
+++ b/lib/ama_validators/phone_number_format_validator.rb
@@ -1,7 +1,7 @@
 class PhoneNumberFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     unless value =~ /\A(\+?1( |-)?)?(\(?[0-9]{3}\)?|[0-9]{3})( |-)?([0-9]{3}( |-)?[0-9]{4})\z/
-      object.errors[attribute] << (options[:message] || "enter a valid 10-digit number (e.g. 587-555-5555)")
+      object.errors.add(attribute, options[:message] || "enter a valid 10-digit number (e.g. 587-555-5555)")
     end
   end
 end

--- a/lib/ama_validators/postal_code_format_validator.rb
+++ b/lib/ama_validators/postal_code_format_validator.rb
@@ -1,8 +1,7 @@
 class PostalCodeFormatValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     unless value =~ /\A(\d{5}((-|\s)\d{4})?|[txTX]\d[abceghjklmnprstvwxyzABCEGHJKLMNPRSTVWXYZ]\s{0,1}\d[abceghjklmnprstvwxyzABCEGHJKLMNPRSTVWXYZ]\d)\z/
-      object.errors[attribute] << (options[:message] || "enter a valid AB or NT postal code (e.g. T4C 1A5)")
+      object.errors.add(attribute, options[:message] || "enter a valid AB or NT postal code (e.g. T4C 1A5)")
     end
   end
 end
-

--- a/lib/ama_validators/province_validator.rb
+++ b/lib/ama_validators/province_validator.rb
@@ -5,7 +5,7 @@ class ProvinceValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
     provinces = PROV_STATE[object.send(options[:country]).to_sym]
     if provinces.present? && !provinces.include?(value)
-      object.errors[attribute] << (options[:message] || 'Province/State should be in selected country.')
+      object.errors.add(attribute, options[:message] || 'Province/State should be in selected country.')
     end
   end
 

--- a/lib/ama_validators/version.rb
+++ b/lib/ama_validators/version.rb
@@ -1,3 +1,3 @@
 module AmaValidators
-  VERSION = "0.0.13"
+  VERSION = "1.0.0"
 end

--- a/spec/alphanumeric_name_format_validator_spec.rb
+++ b/spec/alphanumeric_name_format_validator_spec.rb
@@ -13,7 +13,7 @@ describe AlphanumericNameFormatValidator do
       it 'it returns error message expecified on the validator' do
         n  = subject.new( { attributes: :first_name } )
         invalid_names.each do |invalid_name|
-          expect(n.validate_each(object, :first_name, invalid_name)).to include("We're sorry your name cannot contain any special characters")
+          expect(n.validate_each(object, :first_name, invalid_name).message).to eq("We're sorry your name cannot contain any special characters")
         end
       end
     end
@@ -22,7 +22,7 @@ describe AlphanumericNameFormatValidator do
       it 'it returns error message expecified on the options' do
         n  = subject.new( { message: 'Test error message', attributes: :first_name } )
         invalid_names.each do |invalid_name|
-          expect(n.validate_each(object, :first_name, invalid_name)).to include('Test error message')
+          expect(n.validate_each(object, :first_name, invalid_name).message).to eq('Test error message')
         end
       end
     end

--- a/spec/credit_card_format_validator_spec.rb
+++ b/spec/credit_card_format_validator_spec.rb
@@ -17,7 +17,7 @@ describe CreditCardFormatValidator do
       it 'it returns error message expecified on the validator' do
         n  = subject.new( { attributes: attribute } )
         invalid_credit_card_numbers.each do |invalid_credit_card_number|
-          expect(n.validate_each(object, attribute, invalid_credit_card_number)).to include('enter a valid credit card number (Visa or Mastercard)')
+          expect(n.validate_each(object, attribute, invalid_credit_card_number).message).to eq('enter a valid credit card number (Visa or Mastercard)')
         end
       end
     end
@@ -26,7 +26,7 @@ describe CreditCardFormatValidator do
       it 'it returns error message expecified on the options' do
         n  = subject.new( { message: 'Test error message', attributes: :postal_code } )
         invalid_credit_card_numbers.each do |invalid_credit_card_number|
-          expect(n.validate_each(object, attribute, invalid_credit_card_number)).to include('Test error message')
+          expect(n.validate_each(object, attribute, invalid_credit_card_number).message).to eq('Test error message')
         end
       end
     end

--- a/spec/email_format_validator_spec.rb
+++ b/spec/email_format_validator_spec.rb
@@ -17,7 +17,7 @@ describe EmailFormatValidator do
       it 'it returns error message expecified on the validator' do
         n  = subject.new( { attributes: attribute } )
         invalid_addresses.each do |invalid_address|
-          expect(n.validate_each(object, attribute, invalid_address)).to include('enter a valid email address (e.g. name@example.com)')
+          expect(n.validate_each(object, attribute, invalid_address).message).to eq('enter a valid email address (e.g. name@example.com)')
         end
       end
     end
@@ -26,7 +26,7 @@ describe EmailFormatValidator do
       it 'it returns error message expecified on the options' do
         n  = subject.new( { message: 'Test error message', attributes: :postal_code } )
         invalid_addresses.each do |invalid_address|
-          expect(n.validate_each(object, attribute, invalid_address)).to include('Test error message')
+          expect(n.validate_each(object, attribute, invalid_address).message).to eq('Test error message')
         end
       end
     end

--- a/spec/membership_number_format_validator_spec.rb
+++ b/spec/membership_number_format_validator_spec.rb
@@ -17,7 +17,7 @@ describe MembershipNumberFormatValidator do
       it 'it returns error message expecified on the validator' do
         n  = subject.new( { attributes: attribute } )
         invalid_membership_numbers.each do |invalid_membership_number|
-          expect(n.validate_each(object, attribute, invalid_membership_number)).to include('must be a valid 16-digit membership number')
+          expect(n.validate_each(object, attribute, invalid_membership_number).message).to eq('must be a valid 16-digit membership number')
         end
       end
     end
@@ -26,7 +26,7 @@ describe MembershipNumberFormatValidator do
       it 'it returns error message expecified on the options' do
         n  = subject.new( { message: 'Test error message', attributes: :postal_code } )
         invalid_membership_numbers.each do |invalid_membership_number|
-          expect(n.validate_each(object, attribute, invalid_membership_number)).to include('Test error message')
+          expect(n.validate_each(object, attribute, invalid_membership_number).message).to eq('Test error message')
         end
       end
     end

--- a/spec/name_format_validator_spec.rb
+++ b/spec/name_format_validator_spec.rb
@@ -13,7 +13,7 @@ describe NameFormatValidator do
       it 'it returns error message expecified on the validator' do
         n  = subject.new( { attributes: :first_name } )
         invalid_names.each do |invalid_name|
-          expect(n.validate_each(object, :first_name, invalid_name)).to include("We're sorry your name cannot contain any special characters")
+          expect(n.validate_each(object, :first_name, invalid_name).message).to eq("We're sorry your name cannot contain any special characters")
         end
       end
     end
@@ -22,7 +22,7 @@ describe NameFormatValidator do
       it 'it returns error message expecified on the options' do
         n  = subject.new( { message: 'Test error message', attributes: :first_name } )
         invalid_names.each do |invalid_name|
-          expect(n.validate_each(object, :first_name, invalid_name)).to include('Test error message')
+          expect(n.validate_each(object, :first_name, invalid_name).message).to eq('Test error message')
         end
       end
     end

--- a/spec/phone_number_format_validator_spec.rb
+++ b/spec/phone_number_format_validator_spec.rb
@@ -16,7 +16,7 @@ describe PhoneNumberFormatValidator do
       it 'it returns error message expecified on the validator' do
         n  = subject.new( { attributes: attribute } )
         invalid_phone_numbers.each do |invalid_phone_number|
-          expect(n.validate_each(object, attribute, invalid_phone_number)).to include('enter a valid 10-digit number (e.g. 587-555-5555)')
+          expect(n.validate_each(object, attribute, invalid_phone_number).message).to eq('enter a valid 10-digit number (e.g. 587-555-5555)')
         end
       end
     end
@@ -25,7 +25,7 @@ describe PhoneNumberFormatValidator do
       it 'it returns error message expecified on the options' do
         n  = subject.new( { message: 'Test error message', attributes: attribute } )
         invalid_phone_numbers.each do |invalid_phone_number|
-          expect(n.validate_each(object, attribute, invalid_phone_number)).to include('Test error message')
+          expect(n.validate_each(object, attribute, invalid_phone_number).message).to eq('Test error message')
         end
       end
     end

--- a/spec/postal_code_format_validator_spec.rb
+++ b/spec/postal_code_format_validator_spec.rb
@@ -16,7 +16,7 @@ describe PostalCodeFormatValidator do
       it 'it returns error message expecified on the validator' do
         n  = subject.new( { attributes: attribute } )
         invalid_postal_codes.each do |invalid_postal_code|
-          expect(n.validate_each(object, attribute, invalid_postal_code)).to include('enter a valid AB or NT postal code (e.g. T4C 1A5)')
+          expect(n.validate_each(object, attribute, invalid_postal_code).message).to eq('enter a valid AB or NT postal code (e.g. T4C 1A5)')
         end
       end
     end
@@ -25,7 +25,7 @@ describe PostalCodeFormatValidator do
       it 'it returns error message expecified on the options' do
         n  = subject.new( { message: 'Test error message', attributes: attribute } )
         invalid_postal_codes.each do |invalid_postal_code|
-          expect(n.validate_each(object, attribute, invalid_postal_code)).to include('Test error message')
+          expect(n.validate_each(object, attribute, invalid_postal_code).message).to eq('Test error message')
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,10 @@
 require 'rails/all'
 require 'rspec'
-require 'rspec/autorun'
 require 'simplecov'
 require 'ama_validators'
-require 'coveralls'
-Coveralls.wear!
+require 'pry'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
+  SimpleCov::Formatter::HTMLFormatter
 ]
 SimpleCov.start


### PR DESCRIPTION
🐘

- Updated gem for Rails 6.1 to remove deprecation warning

`DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead.`

- Updated version and tests

ADO LINK:
https://dev.azure.com/AMA-Ent/AMA-Ent/_boards/board/t/Red%20Team/Stories/?workitem=165702

AB#165702